### PR TITLE
VScode用のtextlint設定の追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "textlint.targetPath": "content/*.md"
+}


### PR DESCRIPTION
VScodeのtextlintプラグインでもcontent以下のmdだけを見るように設定ファイルを追加