### PR TITLE
24時にデプロイ実行のGitHub Actionsトリガーを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: Build and Deploy
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '5 15 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
- 正しくは 24時5分に実行（24時ちょうどにした場合、微妙なズレで予定の記事がデプロイされないのを防ぎたい）
- スケジュール自体はUTC実行なので15時をセット