### PR TITLE
毎日0時5分に実行していたdeployのscheduleを停止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,9 @@ name: Build and Deploy
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '5 15 * * *'
+  # しばらく毎日デプロイを走らせる必要がないのでコメントアウト
+  #schedule:
+  #  - cron: '5 15 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
しばらく時間公開の記事を上げる予定がないのと、hugoバージョンアップ対応が必要になるので停止させる。
12月にまた再開するかもしれないので、コメントアウトで対応。