### PR TITLE
.Site.Social を .Site.Params.Social へ変更

### DIFF
--- a/layouts/partials/header/ogp.html
+++ b/layouts/partials/header/ogp.html
@@ -58,5 +58,5 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}
+{{- with .Site.Params.social.facebook_admin }}
 <meta property="fb:admins" content="{{ . }}" />{{ end }}

--- a/layouts/partials/header/twitter.html
+++ b/layouts/partials/header/twitter.html
@@ -20,7 +20,7 @@
 <meta name="twitter:title" content="{{ .Title }}" />
 <meta name="twitter:description"
     content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}" />
-{{ with .Site.Social.twitter -}}
+{{ with .Site.Params.social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}" />
 {{ end -}}
 


### PR DESCRIPTION
Hugo更新で以下のエラーが発生していたので対応

```log
ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.140.0. Implement taxonomy 'social' or use .Site.Params.Social instead.
```