### PR TITLE
[ISSUE-149] Listテンプレート修正

### DIFF
--- a/layouts/partials/_shared/title.html
+++ b/layouts/partials/_shared/title.html
@@ -5,7 +5,7 @@
         <h1 class="sitetitle">{{ .Site.Title }}</h1>
     </a>
     <p class="lead">
-         <a href="https://twitter.com/yamacraft">@yamacraft</a>の雑記。感想は直接お伝えください。<br>
+         <a href="https://x.com/yamacraft">@yamacraft</a>の雑記。感想は直接お伝えください。<br>
          記事フィルタはこちら → <a href="/note/tags/tech/">tech</a> / <a href="/note/tags/work/">work</a> / <a href="/note/tags/diary/">diary</a> / <a href="/note/tags/poem/">poem</a> / <a href="/note/tags/yodan/">yodan</a>
     </p>
 </div>

--- a/layouts/partials/list-partials/pagination.html
+++ b/layouts/partials/list-partials/pagination.html
@@ -1,0 +1,25 @@
+<!-- Pagination
+================================================== -->
+<div class="bottompagination">
+  <div class="navigation text-center" role="navigation">
+    {{ if gt .TotalPages 1 }}
+      <div class="pagination">
+        {{ if .HasPrev }}
+          <a class="ml-1 mr-1" href="{{.Prev.URL}}">&laquo; Prev</a>
+          <a class="ml-1 mr-1" href="{{.Prev.URL}}">{{ .Prev.PageNumber }}</a>
+        {{ else }}
+          <span>&laquo; Prev</span>
+        {{ end }}
+
+        <span class="ml-1 mr-1">{{ .PageNumber }}</span>
+
+        {{ if .HasNext }}
+          <a class="ml-1 mr-1" href="{{.Next.URL}}">{{ .Next.PageNumber }}</a>
+          <a class="ml-1 mr-1" href="{{.Next.URL}}">Next &raquo;</a>
+        {{ else }}
+          <span>Next &raquo;</span>
+        {{ end }}
+      </div>
+    {{ end }}
+  </div>
+</div>

--- a/layouts/partials/list-partials/postbox.html
+++ b/layouts/partials/list-partials/postbox.html
@@ -1,0 +1,34 @@
+<!-- begin post -->
+<div class="col-lg-4 col-md-6 mb-30px card-group">
+    <div class="card h-100">
+        <div class="maxthumb">
+            <a href="{{ .Permalink }}">
+                {{$images := .Resources.ByType "image"}}
+                {{with $images.GetMatch "*cover*" }}
+                    <img class="img-fluid" src="{{ .Permalink }}" alt="A thumbnail image">
+                {{end}}                
+            </a>
+        </div>
+        <div class="card-body">
+            <h2 class="card-title"><a class="text-dark" href="{{ .Permalink }}">{{ .Title }}</a></h2>
+            <h4 class="card-text">{{ .Summary | plainify | truncate 140 }}</h4>            
+        </div>
+        <div class="card-footer bg-white">
+            <div class="wrapfooter">
+                {{if isset .Site.Params "author"}}
+                {{if isset .Site.Params "author_thumb"}}
+                    <span class="meta-footer-thumb">
+                    <img class="author-thumb" src="{{ .Site.Params.author_thumb | urlize | relURL  }}" alt="{{ .Site.Params.author }}">
+                    </span>                
+                    <span class="author-meta">
+                    <span class="post-name">{{ .Site.Params.author }}</a></span><br/>
+                {{end}}
+                {{end}}
+                <span class="post-date">{{ dateFormat "Jan 2, 2006" .PublishDate }} - {{ .ReadingTime }} min read </span>
+                <span class="post-read-more"><a href="{{ .Permalink }}" title="Read Story"><svg class="svgIcon-use" width="25" height="25" viewbox="0 0 25 25"><path d="M19 6c0-1.1-.9-2-2-2H8c-1.1 0-2 .9-2 2v14.66h.012c.01.103.045.204.12.285a.5.5 0 0 0 .706.03L12.5 16.85l5.662 4.126a.508.508 0 0 0 .708-.03.5.5 0 0 0 .118-.285H19V6zm-6.838 9.97L7 19.636V6c0-.55.45-1 1-1h9c.55 0 1 .45 1 1v13.637l-5.162-3.668a.49.49 0 0 0-.676 0z" fill-rule="evenodd"></path></svg></a></span>
+                <div class="clearfix"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- end post -->


### PR DESCRIPTION
#149 

- mediumishテーマを最終更新版にアップデート
  - Listテンプレートのpagenationの表示が崩れていたので、いったん中央配置は崩れないように対応
- List内のカードのサマリーがhtmlタグ付きで出力されるようになっていたので、htmlタグを出さないように修正
  - サマリー自体も表示文字数が増えているようだったので、140字に制限
- トップのXアカウントへのリンクがtwitter.comのままだったので、x.comに修正